### PR TITLE
change the order of Vecdb and ast settings to match vscode

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/settings/AppSettingsComponent.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/settings/AppSettingsComponent.kt
@@ -85,19 +85,21 @@ class AppSettingsComponent {
 
         experimentalPanel = FormBuilder.createFormBuilder().run {
             addComponent(TitledSeparator(RefactAIBundle.message("advancedSettings.experimentalFeatures")))
-            addComponent(astCheckbox, UIUtil.LARGE_VGAP)
+
+            addComponent(vecdbCheckbox, UIUtil.LARGE_VGAP)
             addComponent(
                 JBLabel(
-                    RefactAIBundle.message("advancedSettings.useMultipleFilesCompletionDescription"),
+                    RefactAIBundle.message("advancedSettings.useVecDBDescription"),
                     UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER
                 ).apply {
                     setCopyable(true)
                 }, 0
             )
-            addComponent(vecdbCheckbox, UIUtil.LARGE_VGAP)
+
+            addComponent(astCheckbox, UIUtil.LARGE_VGAP)
             addComponent(
                 JBLabel(
-                    RefactAIBundle.message("advancedSettings.useVecDBDescription"),
+                    RefactAIBundle.message("advancedSettings.useMultipleFilesCompletionDescription"),
                     UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER
                 ).apply {
                     setCopyable(true)


### PR DESCRIPTION
Changes the order of the vecdbdb and ast settings to match the order in vscode.