### PR TITLE
ci: allow branch names to have a slash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ fun getVersionString(baseVersion: String): String {
     if (System.getenv("PUBLISH_EAP") != "1" &&
         tag.isNotEmpty() && tag.contains(baseVersion)) return baseVersion
 
-    val branch = "git rev-parse --abbrev-ref HEAD".runCommand(workingDir = rootDir)
+    val branch = "git rev-parse --abbrev-ref HEAD".runCommand(workingDir = rootDir).replace("/", "-")
     val numberOfCommits = if (branch == "main") {
         val lastTag = "git describe --tags --abbrev=0 @^".runCommand(workingDir = rootDir)
         "git rev-list ${lastTag}..HEAD --count".runCommand(workingDir = rootDir)

--- a/refact_lsp
+++ b/refact_lsp
@@ -1,1 +1,1 @@
-dev
+main


### PR DESCRIPTION
Fixes an issue where `/` in the branch name would cause gradle to create an extra directory