### PR TITLE
Feature: ACTIVE_DOC support

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/Initializer.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/Initializer.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.smallcloud.refactai.listeners.UninstallListener
+import com.smallcloud.refactai.lsp.LSPActiveDocNotifierService
 import com.smallcloud.refactai.notifications.notificationStartup
 import com.smallcloud.refactai.panes.sharedchat.ChatPaneInvokeAction
 import com.smallcloud.refactai.privacy.PrivacyService
@@ -31,6 +32,7 @@ class Initializer : StartupActivity, Disposable {
             UpdateChecker.instance
         }
         getLSPProcessHolder(project)
+        project.getService(LSPActiveDocNotifierService::class.java)
         PrivacyService.instance.projectOpened(project)
     }
 

--- a/src/main/kotlin/com/smallcloud/refactai/lsp/LSPActiveDocNotifierService.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/lsp/LSPActiveDocNotifierService.kt
@@ -1,0 +1,21 @@
+package com.smallcloud.refactai.lsp
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.editor.Editor
+import com.smallcloud.refactai.listeners.SelectionChangedNotifier
+
+class LSPActiveDocNotifierService(val project: Project): Disposable {
+    init {
+        ApplicationManager.getApplication().messageBus.connect(this)
+            .subscribe(SelectionChangedNotifier.TOPIC, object : SelectionChangedNotifier {
+            override fun isEditorChanged(editor: Editor?) {
+                if (editor == null) return
+                lspSetActiveDocument(editor)
+            }
+        })
+    }
+
+    override fun dispose() {}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -143,6 +143,7 @@ integrated into a single package that follows your privacy settings.</p>
         <projectService serviceImplementation="com.smallcloud.refactai.statistic.UsageStats"/>
         <applicationService serviceImplementation="com.smallcloud.refactai.UpdateChecker"/>
         <projectService serviceImplementation="com.smallcloud.refactai.lsp.LSPProcessHolder"/>
+        <projectService serviceImplementation="com.smallcloud.refactai.lsp.LSPActiveDocNotifierService" />
     </extensions>
     <actions>
         <action class="com.smallcloud.refactai.listeners.TabPressedAction"


### PR DESCRIPTION
# Feature: ACTIVE_DOC support

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: On active file change we are not sending the new file for `/v1/lsp-set-active-document` handler in LSP
- Solution: Implemented new service which listens for editor tab being changed and then sends a message for LSP via `lspSetActiveDocument`
- [Any background context or related links?](https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=80172611)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Run the IDE with Refact plugin pre-installed
- Step 2: Change active editors
- Step 3: See that LSP is getting a new file path for current active editor

## Screenshots (if applicable)
## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.