### PR TITLE
Fix: Open Chat instruction selects range of code in active editor

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/code_lens/CodeLensAction.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/code_lens/CodeLensAction.kt
@@ -42,7 +42,6 @@ class CodeLensAction(
             .replace("%CODE_SELECTION%", text)
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun actionPerformed() {
         val chat = editor.project?.let { ToolWindowManager.getInstance(it).getToolWindow("Refact") }
         chat?.activate {
@@ -52,17 +51,15 @@ class CodeLensAction(
 
         // If content is empty, then it's "Open Chat" instruction, selecting range of code in active tab
         if (contentMsg.isEmpty()) {
-            GlobalScope.launch {
+            CoroutineScope(Dispatchers.Main).launch {
                 delay(500)
-                withContext(Dispatchers.Main) {
-                    val pos1 = LogicalPosition(line1, 0)
-                    val pos2 = LogicalPosition(line2, editor.document.getLineEndOffset(line2))
+                val pos1 = LogicalPosition(line1, 0)
+                val pos2 = LogicalPosition(line2, editor.document.getLineEndOffset(line2))
 
-                    editor.selectionModel.setSelection(
-                        editor.logicalPositionToOffset(pos1),
-                        editor.logicalPositionToOffset(pos2)
-                    )
-                }
+                editor.selectionModel.setSelection(
+                    editor.logicalPositionToOffset(pos1),
+                    editor.logicalPositionToOffset(pos2)
+                )
             }
         }
     }


### PR DESCRIPTION
Added logic of lines selection in active editor's tab, if `contentMsg` is empty (no messages were provided)