### PR TITLE
fix(maybe): JB random colour change

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/browser/ChatWebView.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/browser/ChatWebView.kt
@@ -262,7 +262,11 @@ class ChatWebView(val editor: Editor, val messageHandler: (event: Events.FromCha
                         RefactChat.render(element, config);
                     };
                     
-                    document.body.className = config.appearance === "dark" ? "vscode-dark" : "vscode-light";
+                    if(config.themeProps.appearance === "dark") {
+                      document.body.className = "vscode-dark";
+                    } else if (config.themeProps.appearance === "light") {
+                      document.body.className = "vscode-light";
+                    }
                                        
                     const script = document.createElement("script");
                     script.onload = loadChatJs;


### PR DESCRIPTION
To recraete:

In dark mode, click `new chat` a lot, then click the menu button.
Chat changes colour to light mode.

Probably caused by reading the property from config, so the scrpt was setting the them to vscode-light