### PR TITLE
fix: chat crashing when ide opens.

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/status_bar/StatusBarWidget.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/status_bar/StatusBarWidget.kt
@@ -179,7 +179,10 @@ class SMCStatusBarWidget(project: Project) : EditorBasedWidget(project), CustomS
                 }
 
             })
-        project.messageBus.connect(PluginState.instance)
+
+        ApplicationManager.getApplication()
+            .messageBus
+            .connect(this)
             .subscribe(LSPProcessHolderChangedNotifier.TOPIC, object : LSPProcessHolderChangedNotifier {
                 override fun lspIsActive(isActive: Boolean) {
                     update(null)


### PR DESCRIPTION
+ Chat would freeze when open running `runIDE`

Also: [P1 on this list](https://refact.fibery.io/Software_Development/Feature/JB-Giant-list-of-problems-85)
#234 #230 #229 #227 #225 #218 

Caused by the text update in the status bar

To recreate: close and open the ide and click on the error message popup on the bottom right.
