### PR TITLE
Edt throwable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
 
     // test libraries
     testImplementation(kotlin("test"))
+    testImplementation("org.mockito:mockito-core:5.10.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+
     intellijPlatform {
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
 

--- a/src/main/kotlin/com/smallcloud/refactai/modes/ModeProvider.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/modes/ModeProvider.kt
@@ -65,16 +65,25 @@ class ModeProvider(
 
     fun beforeDocumentChangeNonBulk(event: DocumentEvent?, editor: Editor) {
         if (event?.newFragment.toString() == DUMMY_IDENTIFIER) return
-        activeMode?.beforeDocumentChangeNonBulk(DocumentEventExtra(event, editor, currentTimeMillis()))
+        // Ensure we're on EDT for UI operations
+        ApplicationManager.getApplication().invokeLater {
+            activeMode?.beforeDocumentChangeNonBulk(DocumentEventExtra(event, editor, currentTimeMillis()))
+        }
     }
 
     fun onTextChange(event: DocumentEvent?, editor: Editor, force: Boolean) {
         if (event?.newFragment.toString() == DUMMY_IDENTIFIER) return
-        activeMode?.onTextChange(DocumentEventExtra(event, editor, currentTimeMillis(), force))
+        // Ensure we're on EDT for UI operations
+        ApplicationManager.getApplication().invokeLater {
+            activeMode?.onTextChange(DocumentEventExtra(event, editor, currentTimeMillis(), force))
+        }
     }
 
     fun onCaretChange(event: CaretEvent) {
-        activeMode?.onCaretChange(event)
+        // Ensure we're on EDT for UI operations
+        ApplicationManager.getApplication().invokeLater {
+            activeMode?.onCaretChange(event)
+        }
     }
 
     fun focusGained() {}

--- a/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPane.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPane.kt
@@ -415,7 +415,7 @@ class SharedChatPane(val project: Project) : JPanel(), Disposable {
         }
     }
 
-    private fun showPatch(
+    fun showPatch(
         fileName: String,
         fileText: String,
         onTab: ((com.intellij.openapi.editor.Editor, Caret?, DataContext) -> Unit)? = null,
@@ -446,6 +446,7 @@ class SharedChatPane(val project: Project) : JPanel(), Disposable {
             }
         }
     }
+
 
     private fun handlePatchShow(payload: Events.Patch.ShowPayload) {
         payload.results.forEach { result ->

--- a/src/test/kotlin/com/smallcloud/refactai/modes/ModeProviderTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/modes/ModeProviderTest.kt
@@ -1,0 +1,97 @@
+package com.smallcloud.refactai.modes
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.CaretModel
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.concurrency.AppExecutorUtil
+import com.smallcloud.refactai.modes.completion.structs.DocumentEventExtra
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Test for ModeProvider to verify EDT thread safety
+ */
+class ModeProviderTest : BasePlatformTestCase() {
+
+    /**
+     * Test that verifies the EDT assertion error when calling onTextChange from a background thread
+     */
+    fun testEdtAssertionErrorInOnTextChange() {
+        // Create mock objects
+        val document = mock(Document::class.java)
+        val caretModel = mock(CaretModel::class.java)
+        val caret = mock(Caret::class.java)
+        val project = mock(Project::class.java)
+        val editor = mock(Editor::class.java)
+        
+        // Configure mocks
+        `when`(editor.document).thenReturn(document)
+        `when`(editor.caretModel).thenReturn(caretModel)
+        `when`(caretModel.currentCaret).thenReturn(caret)
+        `when`(editor.project).thenReturn(project)
+        
+        // Create a latch to wait for the background thread to complete
+        val latch = CountDownLatch(1)
+        val exceptionRef = AtomicReference<Throwable>()
+        
+        // Create a custom mode that will trigger the EDT assertion
+        val customMode = object : Mode {
+            override var needToRender: Boolean = true
+            
+            override fun beforeDocumentChangeNonBulk(event: DocumentEventExtra) {}
+            
+            override fun onTextChange(event: DocumentEventExtra) {
+                try {
+                    // This will throw an exception if we're not on EDT
+                    if (!ApplicationManager.getApplication().isDispatchThread) {
+                        throw AssertionError("Not on EDT thread")
+                    }
+                } catch (e: Throwable) {
+                    exceptionRef.set(e)
+                } finally {
+                    latch.countDown()
+                }
+            }
+            
+            override fun onTabPressed(editor: Editor, caret: Caret?, dataContext: com.intellij.openapi.actionSystem.DataContext) {}
+            
+            override fun onEscPressed(editor: Editor, caret: Caret?, dataContext: com.intellij.openapi.actionSystem.DataContext) {}
+            
+            override fun onCaretChange(event: com.intellij.openapi.editor.event.CaretEvent) {}
+            
+            override fun isInActiveState(): Boolean = true
+            
+            override fun show() {}
+            
+            override fun hide() {}
+            
+            override fun cleanup(editor: Editor) {}
+        }
+        
+        // Create a ModeProvider with our custom mode
+        val modeProvider = ModeProvider(editor, mutableMapOf(ModeType.Completion to customMode), customMode)
+        
+        // Call onTextChange from a background thread
+        AppExecutorUtil.getAppScheduledExecutorService().submit {
+            // Create a simple document event (we don't need a real one for this test)
+            val documentEvent = null // We'll use null since we're just testing thread safety
+            modeProvider.onTextChange(documentEvent, editor, false)
+        }
+        
+        // Wait for the background thread to complete
+        assertTrue("Test timed out", latch.await(2, TimeUnit.SECONDS))
+        
+        // Verify that we got an exception about not being on EDT
+        assertNotNull("Should have received an exception", exceptionRef.get())
+        assertTrue("Exception should be about EDT", 
+            exceptionRef.get().message?.contains("EDT") == true || 
+            exceptionRef.get().message?.contains("Dispatch") == true)
+    }
+}

--- a/src/test/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPaneTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPaneTest.kt
@@ -1,0 +1,83 @@
+package com.smallcloud.refactai.panes.sharedchat
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Test for SharedChatPane to verify the deadlock issue with file system refresh under read lock
+ */
+class SharedChatPaneTest : BasePlatformTestCase() {
+    private val logger = Logger.getInstance(SharedChatPaneTest::class.java)
+
+    /**
+     * Test that recreates the issue reported in GitHub issue #192
+     * 
+     * This test simulates the problematic code path in SharedChatPane.showPatch() method
+     * where refreshAndFindFileByPath is called while holding a read lock.
+     * 
+     * The test should fail with an error about performing synchronous refresh under read lock.
+     */
+    @Test
+    fun testDeadlockInShowPatch() {
+        // Create a temporary directory and file for testing
+        val tempDir = Files.createTempDirectory("refact-test")
+        val tempFile = tempDir.resolve("test-file.txt").toFile()
+        tempFile.writeText("Test content")
+        val filePath = tempFile.absolutePath
+        
+        // Create a latch to wait for the operation to complete
+        val latch = CountDownLatch(1)
+        val exceptionRef = AtomicReference<Throwable>()
+        
+        // Execute the test in a background thread to simulate what happens in the actual code
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                // Simulate the problematic code in SharedChatPane.showPatch
+                // This is where the deadlock can occur - calling refreshAndFindFileByPath under read lock
+                ReadAction.run<Throwable> {
+                    logger.info("About to call refreshAndFindFileByPath under read lock")
+                    
+                    // Force a refresh to ensure we're testing the actual refresh behavior
+                    // This should throw an exception about performing synchronous refresh under read lock
+                    LocalFileSystem.getInstance().refresh(false)
+                    
+                    // This is the problematic call that can cause deadlocks
+                    val file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath)
+                    
+                    logger.info("Called refreshAndFindFileByPath under read lock, file: $file")
+                }
+            } catch (e: Throwable) {
+                logger.info("Caught exception: ${e.message}")
+                exceptionRef.set(e)
+            } finally {
+                latch.countDown()
+            }
+        }
+        
+        // Wait for the operation to complete
+        assertTrue("Test timed out", latch.await(5, TimeUnit.SECONDS))
+        
+        // We must get an exception about synchronous refresh under read lock
+        val exception = exceptionRef.get()
+        assertNotNull("Should have received an exception", exception)
+        assertTrue(
+            "Exception should be about synchronous refresh under read lock",
+            exception.message?.contains("Do not perform a synchronous refresh under read lock") == true
+        )
+        
+        // Clean up
+        tempFile.delete()
+        tempDir.toFile().delete()
+    }
+
+}


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/Sprint-2025-03-24-530#Task/JB-Throwable-exceptions-1031
Fixes: #185 #169 and #162 and looks similar to #54 
and confirms #194 still works