### PR TITLE
Fix set capabilities after disposed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
 
     // test libraries
     testImplementation(kotlin("test"))
+    testImplementation("org.mockito:mockito-core:5.10.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
     intellijPlatform {
         create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
 

--- a/src/main/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolder.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolder.kt
@@ -175,7 +175,9 @@ open class LSPProcessHolder(val project: Project) : Disposable {
         set(newValue) {
             if (newValue == field) return
             field = newValue
-            project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC).capabilitiesChanged(field)
+            if(!project.isDisposed) {
+                project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC).capabilitiesChanged(field)
+            }
         }
 
     private fun startProcess() {

--- a/src/main/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolder.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolder.kt
@@ -54,7 +54,7 @@ interface LSPProcessHolderChangedNotifier {
     }
 }
 
-class LSPProcessHolder(val project: Project) : Disposable {
+open class LSPProcessHolder(val project: Project) : Disposable {
     private var process: Process? = null
     private var lastConfig: LSPConfig? = null
     private val loggerScheduler = AppExecutorUtil.createBoundedScheduledExecutorService(
@@ -171,7 +171,7 @@ class LSPProcessHolder(val project: Project) : Disposable {
         }
     }
 
-    var capabilities: LSPCapabilities = LSPCapabilities()
+    open var capabilities: LSPCapabilities = LSPCapabilities()
         set(newValue) {
             if (newValue == field) return
             field = newValue

--- a/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
@@ -3,14 +3,18 @@ package com.smallcloud.refactai.lsp
 import com.intellij.openapi.project.Project
 import com.intellij.serviceContainer.AlreadyDisposedException
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.messages.MessageBus
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Test that demonstrates the "Already disposed" issue in LSPProcessHolder.
+ * This reproduces the specific AlreadyDisposedException from GitHub issue #155.
  */
 class LSPProcessHolderTest : BasePlatformTestCase() {
 
@@ -21,6 +25,12 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
         // Flag to track if the check for project.isDisposed was performed
         var disposedCheckPerformed = false
         
+        // Latch to control test execution flow
+        val latch = CountDownLatch(1)
+        
+        // Flag to control whether to use the fix or not
+        var useDisposedCheck = true
+        
         // Override capabilities setter to track message bus access and disposed checks
         override var capabilities: LSPCapabilities = LSPCapabilities()
             set(newValue) {
@@ -30,21 +40,24 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
                 // Record that we performed the disposed check
                 disposedCheckPerformed = true
                 
-                // This is the fix we're testing - checking if project is disposed
-                if (!project.isDisposed) {
-                    // Record that we accessed the message bus
-                    messageBusAccessed = true
-                    
-                    // Access the message bus (this might throw AlreadyDisposedException)
-                    try {
+                if (useDisposedCheck) {
+                    // This is the fix we're testing - checking if project is disposed
+                    if (!project.isDisposed) {
+                        // Record that we accessed the message bus
+                        messageBusAccessed = true
+                        
+                        // Access the message bus (this might throw AlreadyDisposedException)
                         project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
                             .capabilitiesChanged(field)
-                    } catch (e: Exception) {
-                        // Log the exception but don't rethrow it
-                        println("Exception when accessing message bus: ${e.message}")
+                    } else {
+                        println("Project is disposed, skipping message bus access")
                     }
                 } else {
-                    println("Project is disposed, skipping message bus access")
+                    // Without the fix - directly access messageBus without checking isDisposed
+                    // This will throw AlreadyDisposedException when project is disposed
+                    messageBusAccessed = true
+                    project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
+                        .capabilitiesChanged(field)
                 }
             }
         
@@ -54,60 +67,87 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
             disposedCheckPerformed = false
         }
         
-        // Method to simulate setting capabilities without the fix
-        fun setCapabilitiesWithoutFix(newValue: LSPCapabilities) {
-            if (newValue == capabilities) return
-            capabilities = newValue
+        // Method to simulate the race condition that causes the issue in GitHub #155
+        fun simulateRaceConditionWithScheduledTask(makeProjectDisposed: () -> Unit): AlreadyDisposedException? {
+            var caughtException: AlreadyDisposedException? = null
             
-            // Directly access the message bus without checking if project is disposed
-            try {
-                messageBusAccessed = true
-                project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
-                    .capabilitiesChanged(capabilities)
-            } catch (e: Exception) {
-                // Log the exception but don't rethrow it
-                println("Exception when accessing message bus without fix: ${e.message}")
-            }
-        }
-        
-        // Override other methods that access the project's message bus
-        override fun dispose() {
-            // Add the same check here to prevent exceptions during disposal
-            if (!project.isDisposed) {
-                super.dispose()
-            } else {
-                println("Project is disposed, skipping super.dispose()")
-            }
-        }
-        
-        // Method to simulate the race condition
-        fun simulateRaceCondition(makeProjectDisposed: () -> Unit) {
-            // Start a thread that will set capabilities
-            val thread = Thread {
+            // Schedule a task that will set capabilities (similar to what happens in startProcess())
+            val future = AppExecutorUtil.getAppScheduledExecutorService().submit {
                 try {
-                    // Small delay to ensure the main thread has time to make the project disposed
-                    Thread.sleep(100)
+                    // Wait for the project to be disposed first
+                    latch.await(1, TimeUnit.SECONDS)
                     
-                    // Set capabilities (this will access the message bus)
+                    // This will throw AlreadyDisposedException if project is disposed
+                    // and we're not using the fix
                     capabilities = LSPCapabilities(cloudName = "test-cloud")
                 } catch (e: Exception) {
-                    println("Exception in background thread: ${e.message}")
+                    if (e is AlreadyDisposedException) {
+                        caughtException = e
+                    }
+                    println("Exception in scheduled task: ${e.javaClass.name}: ${e.message}")
                 }
             }
-            
-            // Start the thread
-            thread.start()
             
             // Make the project disposed
             makeProjectDisposed()
             
-            // Wait for the thread to complete
-            thread.join()
+            // Signal the background task to continue
+            latch.countDown()
+            
+            // Wait for the task to complete
+            future.get(2, TimeUnit.SECONDS)
+            
+            return caughtException
+        }
+        
+        // Override startProcess to reproduce the exact call stack from the issue
+        fun simulateStartProcess() {
+            // This simulates the call to setCapabilities from startProcess() in LSPProcessHolder
+            capabilities = LSPCapabilities(cloudName = "test-cloud")
         }
     }
 
     /**
-     * This test uses the TestLspProccessHolder to verify the fix for the "Already disposed" issue.
+     * This test reproduces the exact AlreadyDisposedException from GitHub issue #155.
+     */
+    @Test
+    fun testAlreadyDisposedExceptionReproduction() {
+        // Create mock objects
+        val mockProject = mock(Project::class.java)
+        val mockMessageBus = mock(MessageBus::class.java)
+        val mockPublisher = mock(LSPProcessHolderChangedNotifier::class.java)
+        
+        // Set up the mock project
+        `when`(mockProject.isDisposed).thenReturn(false)
+        `when`(mockProject.messageBus).thenReturn(mockMessageBus)
+        
+        // Set up the mock message bus
+        `when`(mockMessageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)).thenReturn(mockPublisher)
+        
+        // Create the test holder
+        val holder = TestLspProccessHolder(mockProject)
+        
+        // Without the fix - project is disposed and we don't check before accessing messageBus
+        holder.resetTracking()
+        holder.useDisposedCheck = false
+        
+        // Make project disposed and try to access messageBus in a scheduled task
+        val exception = holder.simulateRaceConditionWithScheduledTask {
+            `when`(mockProject.isDisposed).thenReturn(true)
+            // When project is disposed, accessing messageBus should throw AlreadyDisposedException
+            `when`(mockProject.messageBus).thenThrow(
+                AlreadyDisposedException("Already disposed: Project(name=manukyans, containerState=DISPOSED, componentStore=E:\\manukyans) (disposed)")
+            )
+        }
+        
+        // Without the fix, an AlreadyDisposedException should be thrown
+        assertNotNull("AlreadyDisposedException should be thrown without the fix", exception)
+        assertTrue("Exception message should contain 'Already disposed'", 
+            exception?.message?.contains("Already disposed") ?: false)
+    }
+    
+    /**
+     * This test verifies the fix for the "Already disposed" issue.
      */
     @Test
     fun testWithTestLspProcessHolder() {
@@ -129,6 +169,7 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
         // Test case 1: Project is not disposed
         run {
             holder.resetTracking()
+            holder.useDisposedCheck = true
             holder.capabilities = LSPCapabilities(cloudName = "test1")
             
             assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)
@@ -140,6 +181,7 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
         run {
             `when`(mockProject.isDisposed).thenReturn(true)
             holder.resetTracking()
+            holder.useDisposedCheck = true
             holder.capabilities = LSPCapabilities(cloudName = "test2")
             
             assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)

--- a/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
@@ -136,7 +136,7 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
             `when`(mockProject.isDisposed).thenReturn(true)
             // When project is disposed, accessing messageBus should throw AlreadyDisposedException
             `when`(mockProject.messageBus).thenThrow(
-                AlreadyDisposedException("Already disposed: Project(name=manukyans, containerState=DISPOSED, componentStore=E:\\manukyans) (disposed)")
+                AlreadyDisposedException("Already disposed")
             )
         }
         
@@ -146,47 +146,4 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
             exception?.message?.contains("Already disposed") ?: false)
     }
     
-    /**
-     * This test verifies the fix for the "Already disposed" issue.
-     */
-    @Test
-    fun testWithTestLspProcessHolder() {
-        // Create mock objects
-        val mockProject = mock(Project::class.java)
-        val mockMessageBus = mock(MessageBus::class.java)
-        val mockPublisher = mock(LSPProcessHolderChangedNotifier::class.java)
-        
-        // Set up the mock project
-        `when`(mockProject.isDisposed).thenReturn(false)
-        `when`(mockProject.messageBus).thenReturn(mockMessageBus)
-        
-        // Set up the mock message bus
-        `when`(mockMessageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)).thenReturn(mockPublisher)
-        
-        // Create the test holder
-        val holder = TestLspProccessHolder(mockProject)
-        
-        // Test case 1: Project is not disposed
-        run {
-            holder.resetTracking()
-            holder.useDisposedCheck = true
-            holder.capabilities = LSPCapabilities(cloudName = "test1")
-            
-            assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)
-            assertTrue("Message bus should be accessed when project is not disposed", 
-                holder.messageBusAccessed)
-        }
-        
-        // Test case 2: Project is disposed
-        run {
-            `when`(mockProject.isDisposed).thenReturn(true)
-            holder.resetTracking()
-            holder.useDisposedCheck = true
-            holder.capabilities = LSPCapabilities(cloudName = "test2")
-            
-            assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)
-            assertFalse("Message bus should NOT be accessed when project is disposed", 
-                holder.messageBusAccessed)
-        }
-    }
 }

--- a/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
@@ -1,0 +1,150 @@
+package com.smallcloud.refactai.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.serviceContainer.AlreadyDisposedException
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.messages.MessageBus
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+
+/**
+ * Test that demonstrates the "Already disposed" issue in LSPProcessHolder.
+ */
+class LSPProcessHolderTest : BasePlatformTestCase() {
+
+    class TestLspProccessHolder(project: Project) : LSPProcessHolder(project) {
+        // Flag to track if the message bus was accessed
+        var messageBusAccessed = false
+        
+        // Flag to track if the check for project.isDisposed was performed
+        var disposedCheckPerformed = false
+        
+        // Override capabilities setter to track message bus access and disposed checks
+        override var capabilities: LSPCapabilities = LSPCapabilities()
+            set(newValue) {
+                if (newValue == field) return
+                field = newValue
+                
+                // Record that we performed the disposed check
+                disposedCheckPerformed = true
+                
+                // This is the fix we're testing - checking if project is disposed
+                if (!project.isDisposed) {
+                    // Record that we accessed the message bus
+                    messageBusAccessed = true
+                    
+                    // Access the message bus (this might throw AlreadyDisposedException)
+                    try {
+                        project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
+                            .capabilitiesChanged(field)
+                    } catch (e: Exception) {
+                        // Log the exception but don't rethrow it
+                        println("Exception when accessing message bus: ${e.message}")
+                    }
+                } else {
+                    println("Project is disposed, skipping message bus access")
+                }
+            }
+        
+        // Method to reset the tracking flags
+        fun resetTracking() {
+            messageBusAccessed = false
+            disposedCheckPerformed = false
+        }
+        
+        // Method to simulate setting capabilities without the fix
+        fun setCapabilitiesWithoutFix(newValue: LSPCapabilities) {
+            if (newValue == capabilities) return
+            capabilities = newValue
+            
+            // Directly access the message bus without checking if project is disposed
+            try {
+                messageBusAccessed = true
+                project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
+                    .capabilitiesChanged(capabilities)
+            } catch (e: Exception) {
+                // Log the exception but don't rethrow it
+                println("Exception when accessing message bus without fix: ${e.message}")
+            }
+        }
+        
+        // Override other methods that access the project's message bus
+        override fun dispose() {
+            // Add the same check here to prevent exceptions during disposal
+            if (!project.isDisposed) {
+                super.dispose()
+            } else {
+                println("Project is disposed, skipping super.dispose()")
+            }
+        }
+        
+        // Method to simulate the race condition
+        fun simulateRaceCondition(makeProjectDisposed: () -> Unit) {
+            // Start a thread that will set capabilities
+            val thread = Thread {
+                try {
+                    // Small delay to ensure the main thread has time to make the project disposed
+                    Thread.sleep(100)
+                    
+                    // Set capabilities (this will access the message bus)
+                    capabilities = LSPCapabilities(cloudName = "test-cloud")
+                } catch (e: Exception) {
+                    println("Exception in background thread: ${e.message}")
+                }
+            }
+            
+            // Start the thread
+            thread.start()
+            
+            // Make the project disposed
+            makeProjectDisposed()
+            
+            // Wait for the thread to complete
+            thread.join()
+        }
+    }
+
+    /**
+     * This test uses the TestLspProccessHolder to verify the fix for the "Already disposed" issue.
+     */
+    @Test
+    fun testWithTestLspProcessHolder() {
+        // Create mock objects
+        val mockProject = mock(Project::class.java)
+        val mockMessageBus = mock(MessageBus::class.java)
+        val mockPublisher = mock(LSPProcessHolderChangedNotifier::class.java)
+        
+        // Set up the mock project
+        `when`(mockProject.isDisposed).thenReturn(false)
+        `when`(mockProject.messageBus).thenReturn(mockMessageBus)
+        
+        // Set up the mock message bus
+        `when`(mockMessageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)).thenReturn(mockPublisher)
+        
+        // Create the test holder
+        val holder = TestLspProccessHolder(mockProject)
+        
+        // Test case 1: Project is not disposed
+        run {
+            holder.resetTracking()
+            holder.capabilities = LSPCapabilities(cloudName = "test1")
+            
+            assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)
+            assertTrue("Message bus should be accessed when project is not disposed", 
+                holder.messageBusAccessed)
+        }
+        
+        // Test case 2: Project is disposed
+        run {
+            `when`(mockProject.isDisposed).thenReturn(true)
+            holder.resetTracking()
+            holder.capabilities = LSPCapabilities(cloudName = "test2")
+            
+            assertTrue("Disposed check should be performed", holder.disposedCheckPerformed)
+            assertFalse("Message bus should NOT be accessed when project is disposed", 
+                holder.messageBusAccessed)
+        }
+    }
+}

--- a/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
+++ b/src/test/kotlin/com/smallcloud/refactai/lsp/LSPProcessHolderTest.kt
@@ -19,54 +19,10 @@ import java.util.concurrent.TimeUnit
 class LSPProcessHolderTest : BasePlatformTestCase() {
 
     class TestLspProccessHolder(project: Project) : LSPProcessHolder(project) {
-        // Flag to track if the message bus was accessed
-        var messageBusAccessed = false
-        
-        // Flag to track if the check for project.isDisposed was performed
-        var disposedCheckPerformed = false
-        
+
         // Latch to control test execution flow
-        val latch = CountDownLatch(1)
-        
-        // Flag to control whether to use the fix or not
-        var useDisposedCheck = true
-        
-        // Override capabilities setter to track message bus access and disposed checks
-        override var capabilities: LSPCapabilities = LSPCapabilities()
-            set(newValue) {
-                if (newValue == field) return
-                field = newValue
-                
-                // Record that we performed the disposed check
-                disposedCheckPerformed = true
-                
-                if (useDisposedCheck) {
-                    // This is the fix we're testing - checking if project is disposed
-                    if (!project.isDisposed) {
-                        // Record that we accessed the message bus
-                        messageBusAccessed = true
-                        
-                        // Access the message bus (this might throw AlreadyDisposedException)
-                        project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
-                            .capabilitiesChanged(field)
-                    } else {
-                        println("Project is disposed, skipping message bus access")
-                    }
-                } else {
-                    // Without the fix - directly access messageBus without checking isDisposed
-                    // This will throw AlreadyDisposedException when project is disposed
-                    messageBusAccessed = true
-                    project.messageBus.syncPublisher(LSPProcessHolderChangedNotifier.TOPIC)
-                        .capabilitiesChanged(field)
-                }
-            }
-        
-        // Method to reset the tracking flags
-        fun resetTracking() {
-            messageBusAccessed = false
-            disposedCheckPerformed = false
-        }
-        
+        private val latch = CountDownLatch(1)
+
         // Method to simulate the race condition that causes the issue in GitHub #155
         fun simulateRaceConditionWithScheduledTask(makeProjectDisposed: () -> Unit): AlreadyDisposedException? {
             var caughtException: AlreadyDisposedException? = null
@@ -74,11 +30,7 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
             // Schedule a task that will set capabilities (similar to what happens in startProcess())
             val future = AppExecutorUtil.getAppScheduledExecutorService().submit {
                 try {
-                    // Wait for the project to be disposed first
                     latch.await(1, TimeUnit.SECONDS)
-                    
-                    // This will throw AlreadyDisposedException if project is disposed
-                    // and we're not using the fix
                     capabilities = LSPCapabilities(cloudName = "test-cloud")
                 } catch (e: Exception) {
                     if (e is AlreadyDisposedException) {
@@ -87,14 +39,9 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
                     println("Exception in scheduled task: ${e.javaClass.name}: ${e.message}")
                 }
             }
-            
-            // Make the project disposed
+
             makeProjectDisposed()
-            
-            // Signal the background task to continue
             latch.countDown()
-            
-            // Wait for the task to complete
             future.get(2, TimeUnit.SECONDS)
             
             return caughtException
@@ -107,11 +54,8 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
         }
     }
 
-    /**
-     * This test reproduces the exact AlreadyDisposedException from GitHub issue #155.
-     */
     @Test
-    fun testAlreadyDisposedExceptionReproduction() {
+    fun testAlreadyDisposedException() {
         // Create mock objects
         val mockProject = mock(Project::class.java)
         val mockMessageBus = mock(MessageBus::class.java)
@@ -126,24 +70,22 @@ class LSPProcessHolderTest : BasePlatformTestCase() {
         
         // Create the test holder
         val holder = TestLspProccessHolder(mockProject)
-        
-        // Without the fix - project is disposed and we don't check before accessing messageBus
-        holder.resetTracking()
-        holder.useDisposedCheck = false
+
         
         // Make project disposed and try to access messageBus in a scheduled task
         val exception = holder.simulateRaceConditionWithScheduledTask {
             `when`(mockProject.isDisposed).thenReturn(true)
             // When project is disposed, accessing messageBus should throw AlreadyDisposedException
+            // But with the fix, we never access messageBus when project is disposed
             `when`(mockProject.messageBus).thenThrow(
                 AlreadyDisposedException("Already disposed")
             )
         }
         
-        // Without the fix, an AlreadyDisposedException should be thrown
-        assertNotNull("AlreadyDisposedException should be thrown without the fix", exception)
-        assertTrue("Exception message should contain 'Already disposed'", 
-            exception?.message?.contains("Already disposed") ?: false)
+        // With the fix, no exception should be thrown
+        assertNull("With the fix, no AlreadyDisposedException should be thrown", exception)
+        // Verify that the capabilities were still set correctly
+        assertEquals("test-cloud", holder.capabilities.cloudName)
     }
-    
+
 }


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/Sprint-2025-03-24-530#Task/JB-AssertionError-1030
Fixes #155 

Cause: message bus being used after the project was disposed.