### PR TITLE
fix: change chat theme when JB theme or colour scheme changes.

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPane.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/panes/sharedchat/SharedChatPane.kt
@@ -13,6 +13,8 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.colors.EditorColorsListener
+import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.event.SelectionEvent
 import com.intellij.openapi.editor.event.SelectionListener
 import com.intellij.openapi.fileEditor.*
@@ -249,12 +251,15 @@ class SharedChatPane(val project: Project) : JPanel(), Disposable {
         val ef = EditorFactory.getInstance()
         ef.eventMulticaster.addSelectionListener(selectionListener, this)
 
-        UISettings.getInstance().addUISettingsListener(
-            UISettingsListener {
-                ApplicationManager.getApplication().invokeLater {
+        project.messageBus.connect().subscribe(
+            EditorColorsManager.TOPIC,
+            EditorColorsListener {
+            ApplicationManager.getApplication().invokeLater {
+                if(!project.isDisposed) {
                     this@SharedChatPane.setLookAndFeel()
                 }
-            }, this)
+            }
+        })
 
         project.messageBus.connect().subscribe(ProjectManager.TOPIC, object: ProjectManagerListener {
             override fun projectOpened(project: Project) {


### PR DESCRIPTION
Ticket: https://refact.fibery.io/Software_Development/Sprint-2025-03-24-530#Task/JB-Chat-color-scheme-not-changing-before-restart-if-change-Editor-color-Scheme-876

Issue: chat would change colour when changing the theme, but not when changing the colour scheme.

This allows it to do both.