### PR TITLE
Fix: status bar not updating while indexing

### DIFF
--- a/src/main/kotlin/com/smallcloud/refactai/status_bar/StatusBarWidget.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/status_bar/StatusBarWidget.kt
@@ -348,7 +348,7 @@ class SMCStatusBarWidget(project: Project) : EditorBasedWidget(project), CustomS
 
         if (lastRagStatusMb != null) {
             val lastRagStatus = lastRagStatusMb!!
-            if (lastRagStatus.vecdb != null && !listOf("done", "idle").contains(lastRagStatus.vecdb.state)) {
+            if (lastRagStatus.vecdb != null && !listOf("done", "idle", "cooldown").contains(lastRagStatus.vecdb.state)) {
                 val vecdbParsedQty = lastRagStatus.vecdb.filesTotal - lastRagStatus.vecdb.filesUnprocessed
                 return RefactAIBundle.message("statusBar.vecDBProgress", vecdbParsedQty, lastRagStatus.vecdb.filesTotal)
             }


### PR DESCRIPTION
ticket: https://refact.fibery.io/Software_Development/Sprint-2025-03-24-530#Task/JB-Status-bar-improvement-when-VecDB-is-working---P4-1053

similar implementation: https://github.com/smallcloudai/refact-vscode/blob/main/src/statusBar.ts#L188 

Took awhile to figure out `cooldown` needed to be added.