### PR TITLE
up version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 6.5.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = PC


### PR DESCRIPTION
JetBrains 2025.1.* have known bug with freezing UI.
There is workaround: set VM option -Dide.browser.jcef.out-of-process.enabled=false
Unfortunately we can't do it for our plugin only and from plugin itself, so I propose to:
* publish plugin as it
* add information about freezes and solution to the docs and plugin description